### PR TITLE
Fix wording in README for GCP Storage Option

### DIFF
--- a/product-guides/vault/configuring-vault/configure-backup-environment/README.md
+++ b/product-guides/vault/configuring-vault/configure-backup-environment/README.md
@@ -20,4 +20,4 @@ You can configure the storage environment under the **Settings > Backup Environm
 4. Under **Storage Environment**, select the **Storage Type** from the drop-down. As of now, Vault supports the following storage types:
    * [Amazon AWS S3 Storage](amazon-aws-s3-storage-environment/)
    * [Azure Blob](azure-blob-storage-environment.md)
-   * [GCP (Google Cloud Platform)](google-cloud-platform.md), and
+   * [GCP (Google Cloud Platform)](google-cloud-platform.md)


### PR DESCRIPTION
When the cloud environments are listed, there is an additional ', and' after GCP